### PR TITLE
(DOCSP-9710): Install VSCE

### DIFF
--- a/source/includes/steps-install-vsce.yaml
+++ b/source/includes/steps-install-vsce.yaml
@@ -1,0 +1,23 @@
+title: Open the Extensions View.
+level: 4
+ref: open-extensions
+content: |
+    In Visual Studio Code, click the :guilabel:`Extensions` icon
+    in the left navigation.
+
+    Alternatively, you can open the :guilabel:`Extensions` view by
+    pressing:
+
+    - :guilabel:`Control + Shift + X` or
+
+    - :guilabel:`Command + Shift + X`.
+
+---
+title: Search "MongoDB for VS Code" in the extension marketplace.
+level: 4
+ref: search-mongodb-for-vscode
+---
+title: Click :guilabel:`Install` on the "MongoDB for VS Code" extension.
+level: 4
+ref: click-install
+...

--- a/source/install.txt
+++ b/source/install.txt
@@ -11,3 +11,20 @@ Install MongoDB for VS Code
    :backlinks: none
    :depth: 1
    :class: singlecol
+
+Prerequisites
+-------------
+
+Before you can install |vsce|, you must install Visual Studio Code. You
+can download Visual Studio Code from https://code.visualstudio.com/.
+
+Procedure
+---------
+
+.. include:: /includes/steps/install-vsce.rst
+
+Once you install |vsce|, you can :ref:`view data in your deployment
+<vsce-databases-collections>` and :ref:`create Playgrounds to interact
+with your data <vsce-playgrounds>`.
+
+To configure |vsce| settings, see :ref:`vsce-settings`. 


### PR DESCRIPTION
Adding info on how to obtain the Visual Studio Code Extension.

A note: When this is available in the marketplace, I'll add a screenshot to step 1 to help users ensure they're installing the correct extension. Since it's not available on the marketplace yet, we can't grab a screenshot.

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/fea4189/mongodb-vscode/docsworker/DOCSP-9710/install