### PR TITLE
(DOCSP-10287): Add Preview banner

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -11,3 +11,5 @@ Connect to Your MongoDB Deployment
    :backlinks: none
    :depth: 1
    :class: singlecol
+
+.. include:: /includes/fact-vsce-preview.rst

--- a/source/crud-ops.txt
+++ b/source/crud-ops.txt
@@ -11,3 +11,5 @@ Perform CRUD Operations
    :backlinks: none
    :depth: 1
    :class: singlecol
+
+.. include:: /includes/fact-vsce-preview.rst

--- a/source/databases-collections.txt
+++ b/source/databases-collections.txt
@@ -12,6 +12,8 @@ Navigate Your Data
    :depth: 2
    :class: singlecol
 
+.. include:: /includes/fact-vsce-preview.rst
+
 Once you connect to your deployment using |vsce|, use the left
 navigation to:
 

--- a/source/includes/fact-vsce-preview.rst
+++ b/source/includes/fact-vsce-preview.rst
@@ -1,0 +1,6 @@
+.. admonition:: Preview
+   :class: note
+
+   |vsce| is currently available as a **Preview** in the Visual Studio
+   Marketplace. The product and the corresponding documentation may
+   change at any time during the Preview stage.

--- a/source/includes/fact-vsce-preview.rst
+++ b/source/includes/fact-vsce-preview.rst
@@ -2,5 +2,5 @@
    :class: note
 
    |vsce| is currently available as a **Preview** in the Visual Studio
-   Marketplace. The product and the corresponding documentation may
-   change at any time during the Preview stage.
+   Marketplace. The product, its features, and the corresponding
+   documentation may change during the Preview stage.

--- a/source/index.txt
+++ b/source/index.txt
@@ -12,6 +12,8 @@ MongoDB for VS Code
    :depth: 1
    :class: singlecol
 
+.. include:: /includes/fact-vsce-preview.rst
+
 MongoDB provides an extension for
 `Visual Studio Code <https://code.visualstudio.com/>`__ which lets
 you work with MongoDB and your data directly within your coding

--- a/source/install.txt
+++ b/source/install.txt
@@ -12,6 +12,8 @@ Install MongoDB for VS Code
    :depth: 1
    :class: singlecol
 
+.. include:: /includes/fact-vsce-preview.rst
+
 Prerequisites
 -------------
 

--- a/source/playgrounds.txt
+++ b/source/playgrounds.txt
@@ -12,6 +12,8 @@ Explore Your Data with Playgrounds
    :depth: 1
    :class: singlecol
 
+.. include:: /includes/fact-vsce-preview.rst
+
 .. class:: hidden
 
    .. toctree::

--- a/source/run-agg-pipelines.txt
+++ b/source/run-agg-pipelines.txt
@@ -12,6 +12,8 @@ Run Aggregation Pipelines
    :depth: 2
    :class: singlecol
 
+.. include:: /includes/fact-vsce-preview.rst
+
 You can run :manual:`aggregation pipelines </aggregation>` on your
 collections in |vsce|. Aggregation pipelines consist of
 :manual:`stages </reference/operator/aggregation-pipeline/>` that

--- a/source/settings.txt
+++ b/source/settings.txt
@@ -3,3 +3,5 @@
 ============================
 MongoDB for VS Code Settings
 ============================
+
+.. include:: /includes/fact-vsce-preview.rst


### PR DESCRIPTION
Adding a banner indicating that this is a Preview extension. The content is single-sourced on each page.

Staged: [Index](https://docs-mongodbcom-staging.corp.mongodb.com/f9a4cd6/mongodb-vscode/docsworker/DOCSP-10287/)