### PR TITLE
(DOCSP-10907): Add info on launching mongodb shell for active deployment

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -105,6 +105,45 @@ deployment from which you were disconnected:
 
 .. include:: /includes/steps/activate-connection.rst
 
+Launch MongoDB Shell
+~~~~~~~~~~~~~~~~~~~~
+
+You can connect the
+`MongoDB Shell <https://docs.mongodb.com/mongodb-shell/>`__ or legacy
+:binary:`mongo <mongo>` shell to your active deployment.
+
+Considerations
+``````````````
+
+- The shell that |vsce| uses to connect to your deployment is
+  determined by the :guilabel:`Shell` setting in your
+  :ref:`extension settings <vsce-settings>`. You can choose either
+  the `MongoDB Shell <https://docs.mongodb.com/mongodb-shell/>`__ or
+  legacy :binary:`mongo <mongo>` shell.
+
+- The path to your desired shell must exist in your system's ``PATH``.
+  If the shell specified in your :ref:`settings <vsce-settings>` does
+  not exist in your ``PATH``, |vsce| attempts to use the other shell. If
+  neither shell exists in your ``PATH``, the operation errors.
+
+Procedure
+`````````
+
+To connect the shell to your active deployment:
+
+1. In the |vsce| :guilabel:`Connections` list, right-click your active
+   deployment.
+
+#. Select :guilabel:`Launch MongoDB Shell`.
+
+|vsce| opens the :guilabel:`Terminal` window in VS Code and launches
+the shell connected to your selected deployment.
+
+.. seealso::
+
+   `Perform CRUD Operations in the MongoDB Shell
+   <https://docs.mongodb.com/mongodb-shell/crud>`__ 
+
 .. _vsce-rename-connection:
 
 Rename a Connection

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -121,10 +121,8 @@ Considerations
   the `MongoDB Shell <https://docs.mongodb.com/mongodb-shell/>`__ or
   legacy :binary:`mongo <mongo>` shell.
 
-- The path to your desired shell must exist in your system's ``PATH``.
-  If the shell specified in your :ref:`settings <vsce-settings>` does
-  not exist in your ``PATH``, |vsce| attempts to use the other shell. If
-  neither shell exists in your ``PATH``, the operation errors.
+- The path to your selected shell must exist in your system's ``PATH``.
+  If it does not exist in your ``PATH``, the operation errors.
 
 Procedure
 `````````

--- a/source/index.txt
+++ b/source/index.txt
@@ -29,8 +29,8 @@ You can use MongoDB for |vscode-short| to:
 - :ref:`Connect to a MongoDB Cluster <vsce-connect>`.
 
   - Once you connect to a cluster, you can launch the
-    :binary:`mongo <mongo>` shell and automatically connect the shell
-    to your cluster.
+    `MongoDB Shell <https://docs.mongodb.com/mongodb-shell/>`__ and
+    automatically connect the shell to your cluster.
 
 - :ref:`Navigate your databases, collections, and documents
   <vsce-databases-collections>`.


### PR DESCRIPTION
Added new sub-section under Activate a Connection explaining how once you activate, you can connect the mongodb shell to your deployment.

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker/DOCSP-10907/connect#activate-a-connection