### PR TITLE
(DOCSP-11269): Run selected lines from playground

### DIFF
--- a/source/playgrounds.txt
+++ b/source/playgrounds.txt
@@ -46,6 +46,22 @@ To open a playground and begin interacting with your data:
 Your playground runs against the deployment specified in your
 :ref:`active connection <vsce-connect>`.
 
+Run a Playground
+----------------
+
+To run a playground, click the :guilabel:`Play Button` in VS Code's
+top navigation bar.
+
+Run Selected Lines of a Playground
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you select a section of your playground, you may optionally run only
+the selected portion. Your selection can consist of a single line or multiple lines.
+
+When you select a section of your playground, |vsce| shows the
+:guilabel:`Run Selected Lines from Playground` button. Click this button
+to test specific lines or sections of your playground.
+
 Tutorials
 ---------
 

--- a/source/playgrounds.txt
+++ b/source/playgrounds.txt
@@ -58,9 +58,9 @@ Run Selected Lines of a Playground
 If you select a section of your playground, you may optionally run only
 the selected portion. Your selection can consist of a single line or multiple lines.
 
-When you select a section of your playground, |vsce| shows the
-:guilabel:`Run Selected Lines from Playground` button. Click this button
-to test specific lines or sections of your playground.
+|vsce| shows the :guilabel:`Run Selected Lines from Playground` button
+immediately below your selected section. Click this button to test and
+troubleshoot specific lines or sections of your playground.
 
 Tutorials
 ---------


### PR DESCRIPTION
New functionality letting you run only a selected portion of a playground.

JIRA: [DOCSP-11269](https://jira.mongodb.org/browse/DOCSP-11269)

Staged: [Run a Playground](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker-xlarge/DOCSP-11269/playgrounds#run-a-playground)