### PR TITLE
(DOCSP-11708): Add link to changelog

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -82,3 +82,4 @@ Learn More
       /playgrounds
       /create-cluster-terraform
       /reference
+      Changelog <https://github.com/mongodb-js/vscode/releases>


### PR DESCRIPTION
Staged: [Index Page](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker-xlarge/DOCSP-11708/
)
This is a super simple change but have a quick question for review - Should we make it clearer that we're taking them away from the MongoDB docs when they click this link? Would titling the link something like `View Changelog on GitHub` or `Changelog on GitHub` be better?