### PR TITLE
(DOCSP-11550) Search for documents with a search template

### DIFF
--- a/source/databases-collections.txt
+++ b/source/databases-collections.txt
@@ -66,11 +66,7 @@ To modify your data using |vsce|, use a :ref:`JavaScript Playground
 <vsce-crud>` or launch a shell by right-clicking your active deployment
 in the MongoDB view in the Activity Bar.
 
-.. note::
-
-   You can open a Playground pre-configured for your deployment by 
-   hovering over the :guilabel:`Documents` label in the navigation 
-   panel and clicking the :icon-fa4:`search` icon that appears.
+.. include:: /includes/admonitions/document-search-template.rst
 
 Schema
 ``````

--- a/source/databases-collections.txt
+++ b/source/databases-collections.txt
@@ -66,6 +66,12 @@ To modify your data using |vsce|, use a :ref:`JavaScript Playground
 <vsce-crud>` or launch a shell by right-clicking your active deployment
 in the MongoDB view in the Activity Bar.
 
+.. note::
+
+   You can open a Playground pre-configured for your deployment by 
+   hovering over the :guilabel:`Documents` label in the navigation 
+   panel and clicking the :icon-fa4:`search` icon that appears.
+
 Schema
 ``````
 

--- a/source/includes/admonitions/document-search-template.rst
+++ b/source/includes/admonitions/document-search-template.rst
@@ -1,0 +1,5 @@
+.. note::
+
+   You can open a Playground pre-configured to search your deployment 
+   by hovering over the :guilabel:`Documents` label in the navigation 
+   panel and clicking the :icon-fa4:`search` icon that appears.

--- a/source/includes/admonitions/document-search-template.rst
+++ b/source/includes/admonitions/document-search-template.rst
@@ -1,6 +1,6 @@
 .. note::
 
    You can open a :ref:`JavaScript Playground <vsce-crud>` 
-   pre-configured to search your deployment by hovering over the 
+   pre-configured to search a collection by hovering over the 
    :guilabel:`Documents` label in the navigation panel and clicking the 
    :icon-fa4:`search` icon that appears.

--- a/source/includes/admonitions/document-search-template.rst
+++ b/source/includes/admonitions/document-search-template.rst
@@ -1,5 +1,6 @@
 .. note::
 
-   You can open a Playground pre-configured to search your deployment 
-   by hovering over the :guilabel:`Documents` label in the navigation 
-   panel and clicking the :icon-fa4:`search` icon that appears.
+   You can open a :ref:`JavaScript Playground <vsce-crud>` 
+   pre-configured to search your deployment by hovering over the 
+   :guilabel:`Documents` label in the navigation panel and clicking the 
+   :icon-fa4:`search` icon that appears.

--- a/source/read-document-playground.txt
+++ b/source/read-document-playground.txt
@@ -22,6 +22,19 @@ You can read documents in a collection using the
   </reference/method/db.collection.find>` method to read more 
   than one document.
 
+.. _search-documents-template:
+
+Search Templates
+~~~~~~~~~~~~~~~~
+
+A search template is a Playground pre-configured for your deployment, 
+ready to accept :manual:`find() </reference/method/db.collection.find>` 
+and :manual:`sort() </reference/method/db.collection.sort>` arguments.
+
+You can open a new search template by hovering over the 
+:guilabel:`Documents` label in the navigation panel and clicking the 
+:icon-fa4:`search` icon that appears.
+
 Prerequisites
 -------------
 
@@ -35,18 +48,6 @@ prerequisites before you can read documents with a MongoDB Playground:
 - :ref:`Open a MongoDB Playground <open-playground-for-crud-vsce>`.
 - :ref:`vsce-create-doc-playground` or create documents in a collection
   using a different method.
-
-.. _search-documents-template:
-
-Search Templates
-----------------
-
-A search template is a Playground pre-configured for your deployment, 
-ready to accept find and sort arguments.
-
-You can open a new search template by hovering over the 
-:guilabel:`Documents` label in the navigation panel and clicking the 
-:icon-fa4:`search` icon that appears.
 
 Read One Document
 -----------------

--- a/source/read-document-playground.txt
+++ b/source/read-document-playground.txt
@@ -36,6 +36,18 @@ prerequisites before you can read documents with a MongoDB Playground:
 - :ref:`vsce-create-doc-playground` or create documents in a collection
   using a different method.
 
+.. _search-documents-template:
+
+Search Templates
+----------------
+
+A search template is a Playground pre-configured for your deployment, 
+ready to accept find and sort arguments.
+
+You can open a new search template by hovering over the 
+:guilabel:`Documents` label in the navigation panel and clicking the 
+:icon-fa4:`search` icon that appears.
+
 Read One Document
 -----------------
 

--- a/source/read-document-playground.txt
+++ b/source/read-document-playground.txt
@@ -22,18 +22,7 @@ You can read documents in a collection using the
   </reference/method/db.collection.find>` method to read more 
   than one document.
 
-.. _search-documents-template:
-
-Search Templates
-~~~~~~~~~~~~~~~~
-
-A search template is a Playground pre-configured for your deployment, 
-ready to accept :manual:`find() </reference/method/db.collection.find>` 
-and :manual:`sort() </reference/method/db.collection.sort>` arguments.
-
-You can open a new search template by hovering over the 
-:guilabel:`Documents` label in the navigation panel and clicking the 
-:icon-fa4:`search` icon that appears.
+.. include:: /includes/admonitions/document-search-template.rst
 
 Prerequisites
 -------------


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOCSP-11550)
[Staged - Navigate Your Data, Documents section](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker-xlarge/DOCSP-11550/databases-collections#documents)
[Staged - Read Documents](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker-xlarge/DOCSP-11550/read-document-playground)

Created a note about using the search template Playground & put it on the two suggested pages. 

I think this info is best presented as a note because it's straightforward and easily attachable to sections about searching for documents. I don't think there's anything else to cover in a dedicated section because the template is heavily annotated and Playgrounds are already established.