### PR TITLE
(DOCSP-11929) Quick index creation with playgrounds

### DIFF
--- a/source/databases-collections.txt
+++ b/source/databases-collections.txt
@@ -83,8 +83,8 @@ appear in that collection's documents. If a field exists in all
 documents and its type is consistent throughout the collection, |vsce|
 displays an icon indicating that field's data type.
 
-Indexes
-~~~~~~~
+Manage Indexes
+~~~~~~~~~~~~~~
 
 Your collections's indexes are listed under the :guilabel:`Indexes` 
 heading. When you expand an index, each index key appears with an icon 
@@ -98,7 +98,7 @@ designating its type. Index key types include:
 
 .. note::
 
-   You can open a :ref:`JavaScript Playground <vsce-crud>` 
+   You can open a :ref:`MongoDB Playground <vsce-crud>` 
    pre-configured to create an index by hovering over the 
    :guilabel:`Indexes` label in the navigation panel and clicking the 
    :icon-fa4:`plus` icon that appears.

--- a/source/databases-collections.txt
+++ b/source/databases-collections.txt
@@ -84,11 +84,11 @@ documents and its type is consistent throughout the collection, |vsce|
 displays an icon indicating that field's data type.
 
 Indexes
-```````
+~~~~~~~
 
-Your collections's indexes are listed under the :guilabel:`Indexes` heading.
-When you expand an index, each index key appears with an icon designating
-its type. Index key types include:
+Your collections's indexes are listed under the :guilabel:`Indexes` 
+heading. When you expand an index, each index key appears with an icon 
+designating its type. Index key types include:
 
 - Ascending
 - Descending

--- a/source/databases-collections.txt
+++ b/source/databases-collections.txt
@@ -101,6 +101,13 @@ its type. Index key types include:
    For more information about MongoDB indexes, see the documentation in
    the :manual:`server manual </indexes>`.
 
+.. note::
+
+   You can open a :ref:`JavaScript Playground <vsce-crud>` 
+   pre-configured to create an index by hovering over the 
+   :guilabel:`Indexes` label in the navigation panel and clicking the 
+   :icon-fa4:`plus` icon that appears.
+
 Create a New Database
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/databases-collections.txt
+++ b/source/databases-collections.txt
@@ -96,17 +96,17 @@ its type. Index key types include:
 - Text
 - Hashed
 
-.. seealso::
-
-   For more information about MongoDB indexes, see the documentation in
-   the :manual:`server manual </indexes>`.
-
 .. note::
 
    You can open a :ref:`JavaScript Playground <vsce-crud>` 
    pre-configured to create an index by hovering over the 
    :guilabel:`Indexes` label in the navigation panel and clicking the 
    :icon-fa4:`plus` icon that appears.
+
+.. seealso::
+
+   For more information about MongoDB indexes, see the documentation in
+   the :manual:`server manual </indexes>`.
 
 Create a New Database
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/databases-collections.txt
+++ b/source/databases-collections.txt
@@ -37,10 +37,10 @@ Databases and Collections
 When you expand an active connection, |vsce| shows the databases in that
 deployment. Click a database to view the collections it contains.
 
+Click a collection to view its documents, schema, and indexes.
+
 View Collection Documents and Schema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Click a collection to view its documents, schema, and indexes.
 
 Documents
 ``````````


### PR DESCRIPTION
[JIRA](https://github.com/mongodb-js/vscode/pull/161)
[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker-xlarge/DOCSP-11929/databases-collections#indexes)

Added a note that mirrors the tip to search a collection. I think this is the most clear and concise way to present this info given that this small indexes section links off to the server docs for more info about indexes.

As an alternative I considered a full new page under "Explore Your Data with Playgrounds," similar to "Run Aggregation Pipelines." That could be good if we want to really dive into using indexes in playgrounds, but I don't think it's necessary.