### PR TITLE
(DOCSP-12779): console.log for playgrounds

### DIFF
--- a/source/playgrounds.txt
+++ b/source/playgrounds.txt
@@ -131,6 +131,20 @@ of your playground.
 immediately above your selected section. Click this link to test and
 troubleshoot specific lines or sections of your playground.
 
+Log to Console from a Playground
+--------------------------------
+
+|vsce| supports the following methods to log messages to the console.
+Logged messages appear in the :guilabel:`Output` panel in VSCode.
+
+- ``console.log()``
+- ``print()``
+- ``printjson()``
+
+Logging to the console can be useful to track the output of certain
+commands in your playground, such as results after a particular query or
+aggregation.
+
 Tutorials
 ---------
 


### PR DESCRIPTION
Small update explaining new functionality for logging.

Staged: [Log to Console from a Playground](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker-xlarge/DOCSP-12779/playgrounds#log-to-console-from-a-playground)