### PR TITLE
DOCSP-13084 Display Playground Output in editor

### DIFF
--- a/source/commands.txt
+++ b/source/commands.txt
@@ -149,8 +149,10 @@ Run these commands from the Command Palette to create and run
        Your playground runs against the deployment specified in your
        active connection.
        
-       |vsce| outputs the results of your playground in the
-       :guilabel:`Output` view in VS Code.
+       |vsce| splits your playground window to display the results in 
+       a pane titled :guilabel:`Playground Results.json` to the right 
+       of your playground. If you disabled split-view, |vsce| displays 
+       playground results in a new tab to the right of your playground.
 
 |vsce| View Commands
 --------------------

--- a/source/commands.txt
+++ b/source/commands.txt
@@ -153,7 +153,8 @@ Run these commands from the Command Palette to create and run
        a pane titled :guilabel:`Playground Results.json` to the right 
        of your playground. If you disabled split-view for your VS Code 
        Editor window, |vsce| displays the playground results in a new 
-       tab to the right of your playground.
+       tab to the right of your playground. If you manually move your 
+       playground results, |vsce| displays the results in that tab.
 
 |vsce| View Commands
 --------------------

--- a/source/commands.txt
+++ b/source/commands.txt
@@ -151,8 +151,9 @@ Run these commands from the Command Palette to create and run
        
        |vsce| splits your playground window to display the results in 
        a pane titled :guilabel:`Playground Results.json` to the right 
-       of your playground. If you disabled split-view, |vsce| displays 
-       playground results in a new tab to the right of your playground.
+       of your playground. If you disabled split-view for your VS Code 
+       Editor window, |vsce| displays the playground results in a new 
+       tab to the right of your playground.
 
 |vsce| View Commands
 --------------------

--- a/source/create-document-playground.txt
+++ b/source/create-document-playground.txt
@@ -77,9 +77,7 @@ The following example:
      { "_id" : 1, "item" : "abc", "price" : 10, "quantity" : 2, "date" : new Date("2014-03-01T08:00:00Z")}
    );
 
-When you press the :guilabel:`Play Button`, this operation outputs the
-following document to the :guilabel:`Output` view in Visual Studio
-Code:
+.. include:: /includes/fact-playground-results.rst
 
 .. code-block:: javascript
 
@@ -140,9 +138,7 @@ The following example:
      { "_id" : 9, "item" : "abc", "price" : 10, "quantity" : 5, "date" : new Date("2016-02-06T20:20:13Z") },
    ]);
 
-When you press the :guilabel:`Play Button`, this operation outputs the
-following document to the :guilabel:`Output` view in Visual Studio
-Code:
+.. include:: /includes/fact-playground-results.rst
 
 .. code-block:: javascript
    :copyable: false

--- a/source/delete-document-playground.txt
+++ b/source/delete-document-playground.txt
@@ -77,9 +77,7 @@ The following example:
      { "_id" : 1 }
    );
 
-When you press the :guilabel:`Play Button`, this operation outputs the
-following document to the :guilabel:`Output` view in Visual Studio
-Code:
+.. include:: /includes/fact-playground-results.rst
 
 .. code-block:: javascript
 
@@ -129,9 +127,7 @@ The following example:
      { "item" : "abc" }
    );
 
-When you press the :guilabel:`Play Button`, this operation outputs the
-following document to the :guilabel:`Output` view in Visual Studio
-Code:
+.. include:: /includes/fact-playground-results.rst
 
 .. code-block:: javascript
    :copyable: false

--- a/source/includes/fact-playground-results.rst
+++ b/source/includes/fact-playground-results.rst
@@ -1,3 +1,4 @@
 When you press the :guilabel:`Play Button`, |vsce| splits your 
-Playground and outputs the following document in the :guilabel:`Playground Results.json` pane. If you disabled split-view, 
+Playground and outputs the following document in the 
+:guilabel:`Playground Results.json` pane. If you disabled split-view, 
 |vsce| outputs the following document in a new tab.

--- a/source/includes/fact-playground-results.rst
+++ b/source/includes/fact-playground-results.rst
@@ -1,0 +1,3 @@
+When you press the :guilabel:`Play Button`, |vsce| splits your 
+Playground and outputs the following document in the :guilabel:`Playground Results.json` pane. If you disabled split-view, 
+|vsce| outputs the following document in a new tab.

--- a/source/includes/fact-playground-results.rst
+++ b/source/includes/fact-playground-results.rst
@@ -1,4 +1,5 @@
 When you press the :guilabel:`Play Button`, |vsce| splits your 
 Playground and outputs the following document in the 
 :guilabel:`Playground Results.json` pane. If you disabled split-view, 
-|vsce| outputs the following document in a new tab.
+|vsce| outputs the following document in a new tab. If you manually 
+move your playground results, |vsce| displays the results in that tab.

--- a/source/includes/run-playground.rst
+++ b/source/includes/run-playground.rst
@@ -1,3 +1,5 @@
 To run your Playground, press the :guilabel:`Play Button` at the top
-right of the Playground View. |vsce| outputs the results of your
-playground to the :guilabel:`Output` view in Visual Studio Code.
+right of the Playground View. |vsce| splits your Playground and outputs 
+the results of your Playground in the :guilabel:`Playground 
+Results.json` pane. If you disabled split-view, |vsce| outputs the 
+results of your Playground in a new tab. 

--- a/source/playgrounds.txt
+++ b/source/playgrounds.txt
@@ -30,6 +30,14 @@ files with the ``.mongodb`` extension as playgrounds.
 
 .. include:: /includes/admonitions/note-playgrounds.rst
 
+|vsce| splits your Playground window to display the results of your 
+Playground in |json| format in the right-side pane labeled ``Playground 
+Results.json``. If you disabled split-view, |vsce| displays the 
+Playground results in |json| format in a new tab to the right of 
+your Playground. You cannot edit the results in the results pane. 
+Instead, you can save the results to a file and edit the results in the 
+saved file. 
+
 Prerequisite
 ------------
 

--- a/source/playgrounds.txt
+++ b/source/playgrounds.txt
@@ -35,8 +35,7 @@ Playground in |json| format in the right-side pane labeled ``Playground
 Results.json``. If you disabled split-view, |vsce| displays the 
 Playground results in |json| format in a new tab to the right of 
 your Playground. You cannot edit the results in the results pane. 
-Instead, you can save the results to a file and edit the results in the 
-saved file. 
+You can save the results to a file. 
 
 Prerequisite
 ------------

--- a/source/read-document-playground.txt
+++ b/source/read-document-playground.txt
@@ -82,9 +82,7 @@ The following example:
      { "_id" : 0 }
    );
 
-When you press the :guilabel:`Play Button`, this operation outputs the
-following document to the :guilabel:`Output` view in Visual Studio
-Code:
+.. include:: /includes/fact-playground-results.rst
 
 .. code-block:: javascript
 
@@ -134,9 +132,7 @@ The following example:
      { "price" : 1 }
    );
 
-When you press the :guilabel:`Play Button`, this operation outputs the
-following document to the :guilabel:`Output` view in Visual Studio
-Code:
+.. include:: /includes/fact-playground-results.rst
 
 .. code-block:: javascript
    :copyable: false

--- a/source/run-agg-pipelines.txt
+++ b/source/run-agg-pipelines.txt
@@ -113,9 +113,9 @@ This pipeline:
      stage adds a new field to the output called ``totalSaleAmount``,
      which is the culmination of the item's ``price`` and ``quantity``.
 
-When you press the :guilabel:`Play Button`, this operation outputs the
-following documents to the :guilabel:`Output` view in Visual Studio
-Code:
+When you press the :guilabel:`Play Button`, |vsce| splits your 
+playground and outputs the following document in the :guilabel:`Playground Results.json` pane. If you disabled split-view, 
+|vsce| outputs the following document in a new tab:
 
 .. code-block:: javascript
    :copyable: false

--- a/source/run-agg-pipelines.txt
+++ b/source/run-agg-pipelines.txt
@@ -114,7 +114,8 @@ This pipeline:
      which is the culmination of the item's ``price`` and ``quantity``.
 
 When you press the :guilabel:`Play Button`, |vsce| splits your 
-playground and outputs the following document in the :guilabel:`Playground Results.json` pane. If you disabled split-view, 
+playground and outputs the following document in the 
+:guilabel:`Playground Results.json` pane. If you disabled split-view, 
 |vsce| outputs the following document in a new tab:
 
 .. code-block:: javascript

--- a/source/update-document-playground.txt
+++ b/source/update-document-playground.txt
@@ -80,9 +80,7 @@ The following example:
     { $inc: { "quantity" : 1 }}
   );
 
-When you press the :guilabel:`Play Button`, this operation outputs the
-following document to the :guilabel:`Output` view in Visual Studio
-Code:
+.. include:: /includes/fact-playground-results.rst
 
 .. code-block:: javascript
    :copyable: false
@@ -139,9 +137,7 @@ The following example:
      { $set: { "price": 9 }}
    );
 
-When you press the :guilabel:`Play Button`, this operation outputs the
-following document to the :guilabel:`Output` view in Visual Studio
-Code:
+.. include:: /includes/fact-playground-results.rst
 
 .. code-block:: javascript
    :copyable: false


### PR DESCRIPTION
- [JIRA](https://jira.mongodb.org/browse/DOCSP-13084)
- Stage: 
  - [Explore Your Data with Playgrounds](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker-xlarge/DOCSP-13084/playgrounds)
  - [Create Documents](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker-xlarge/DOCSP-13084/create-document-playground)
  - [Read Documents](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker-xlarge/DOCSP-13084/read-document-playground)
  - [Update Documents](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker-xlarge/DOCSP-13084/update-document-playground)
  - [Delete Documents](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker-xlarge/DOCSP-13084/delete-document-playground)
  - [Run Aggregation Pipelines](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker-xlarge/DOCSP-13084/run-agg-pipelines)
  - [MongoDB for VS Code Commands](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker-xlarge/DOCSP-13084/commands#playground-commands)