### PR TITLE
(DOCSP-19772): VSCode export to language

### DIFF
--- a/source/export-to-language.txt
+++ b/source/export-to-language.txt
@@ -12,9 +12,10 @@ Export a Query or Pipeline to Language
    :depth: 1
    :class: singlecol
 
-You can export query documents and aggregation pipelines from a
-:ref:`playground <vsce-playgrounds>` to a programming language. You can
-export to:
+You can export and translate query documents and aggregation pipelines
+from a :ref:`playground <vsce-playgrounds>` into a programming language.
+You can export queries and pipelines to one of the following
+languages:
 
 - C# 
 - Java 
@@ -25,20 +26,24 @@ Prerequisites
 -------------
 
 You must open a playground that contains a query document or pipeline
-you want to export. These tutorials use the default playground template.
+you want to export. 
 
-To open a new playground:
+These tutorials use the default playground template.
+
+To open a new playground containing the default template:
 
 .. include:: /includes/steps/open-new-playground.rst
 
 Export a Query Document
 -----------------------
 
+To export a query document:
+
 .. include:: /includes/steps/export-to-language-query.rst
 
 Export an Aggregation Pipeline
 ------------------------------
 
-To export a query document or aggregation pipeline:
+To export an aggregation pipeline:
 
 .. include:: /includes/steps/export-to-language-pipeline.rst

--- a/source/export-to-language.txt
+++ b/source/export-to-language.txt
@@ -1,0 +1,44 @@
+.. _vsce-export-to-language:
+
+======================================
+Export a Query or Pipeline to Language
+======================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+You can export query documents and aggregation pipelines from a
+:ref:`playground <vsce-playgrounds>` to a programming language. You can
+export to:
+
+- C# 
+- Java 
+- Node
+- Python
+
+Prerequisites
+-------------
+
+You must open a playground that contains a query document or pipeline
+you want to export. These tutorials use the default playground template.
+
+To open a new playground:
+
+.. include:: /includes/steps/open-new-playground.rst
+
+Export a Query Document
+-----------------------
+
+.. include:: /includes/steps/export-to-language-query.rst
+
+Export an Aggregation Pipeline
+------------------------------
+
+To export a query document or aggregation pipeline:
+
+.. include:: /includes/steps/export-to-language-pipeline.rst

--- a/source/export-to-language.txt
+++ b/source/export-to-language.txt
@@ -14,8 +14,7 @@ Export a Query or Pipeline to Language
 
 You can export and translate query documents and aggregation pipelines
 from a :ref:`playground <vsce-playgrounds>` into a programming language.
-You can export queries and pipelines to one of the following
-languages:
+You can export queries and pipelines to the following languages:
 
 - C# 
 - Java 

--- a/source/export-to-language.txt
+++ b/source/export-to-language.txt
@@ -27,7 +27,7 @@ Prerequisites
 You must open a playground that contains a query document or pipeline
 you want to export. 
 
-These tutorials use the default playground template.
+The tutorials on this page use the default playground template.
 
 To open a new playground containing the default template:
 

--- a/source/export-to-language.txt
+++ b/source/export-to-language.txt
@@ -18,7 +18,7 @@ You can export queries and pipelines to the following languages:
 
 - C# 
 - Java 
-- Node
+- Node.js
 - Python
 
 Prerequisites

--- a/source/includes/blank-playground.rst
+++ b/source/includes/blank-playground.rst
@@ -1,2 +1,2 @@
-To use this example, **start with a blank MongoDB Playground** by
+To run this example, **start with a blank MongoDB Playground** by
 clearing the template Playground if it is loaded.

--- a/source/includes/fact-export-options.rst
+++ b/source/includes/fact-export-options.rst
@@ -1,0 +1,6 @@
+You can choose whether to include import statements, driver syntax,
+or both in your exported code.
+
+At the top of the newly opened VS Code window containing your
+exported code, use the :guilabel:`Import Statements` and
+:guilabel:`Driver Syntax` toggles to control these options.

--- a/source/includes/fact-export-selection.rst
+++ b/source/includes/fact-export-selection.rst
@@ -1,5 +1,5 @@
-a. Click the light bulb icon that appears after you highlight your
-   code.
+a. When you highlighted your code, a light bulb icon appeared. Click
+   the icon.
 
 #. In the context menu, choose the language you want to export to.
    |vsce| opens a new VS Code window containing the highlighted code

--- a/source/includes/fact-export-selection.rst
+++ b/source/includes/fact-export-selection.rst
@@ -1,0 +1,6 @@
+a. Click the light bulb icon that appears after you highlight your
+   code.
+
+#. In the context menu, choose the language you want to export to.
+   |vsce| opens a new VS Code window containing the highlighted code
+   in your chosen language.

--- a/source/includes/steps-export-to-language-pipeline.yaml
+++ b/source/includes/steps-export-to-language-pipeline.yaml
@@ -1,0 +1,92 @@
+title: Highlight the code you want to export.
+level: 4
+ref: highlight-code
+content: |
+
+   Highlight the aggregation pipeline from the playground template:
+
+   .. code-block:: javascript
+
+      [
+          { $match: { date: { $gte: new Date('2014-01-01'), $lt: new Date('2015-01-01') } } },
+          { $group: { _id: '$item', totalSaleAmount: { $sum: { $multiply: [ '$price', '$quantity' ] } } } }
+      ]
+
+---
+title: Export your selection.
+level: 4
+ref: export-selection
+content: |
+
+   .. include:: /includes/fact-export-selection.rst
+
+   For example, exporting the pipeline from Step 1 to Java results in
+   the following code:
+
+   .. code-block:: java
+
+      Arrays.asList(new Document("$match", 
+          new Document("date", 
+          new Document("$gte", 
+          new java.util.Date(1388534400000L))
+                      .append("$lt", 
+          new java.util.Date(1420070400000L)))), 
+          new Document("$group", 
+          new Document("_id", "$item")
+                  .append("totalSaleAmount", 
+          new Document("$sum", 
+          new Document("$multiply", Arrays.asList("$price", "$quantity"))))))
+---
+title: Configure Export Options
+level: 4
+ref: export-options
+content: |
+
+   .. include:: /includes/fact-export-options.rst
+
+   Including both import statements and driver syntax for the preceding
+   Java code results in this output:
+
+   .. code-block:: java
+
+      import java.util.Arrays;
+      import org.bson.Document;
+      import com.mongodb.MongoClient;
+      import com.mongodb.MongoClientURI;
+      import com.mongodb.client.FindIterable;
+      import com.mongodb.client.MongoCollection;
+      import com.mongodb.client.MongoDatabase;
+      import org.bson.conversions.Bson;
+      import java.util.concurrent.TimeUnit;
+      import org.bson.Document;
+
+      /*
+       * Requires the MongoDB Java Driver.
+       * https://mongodb.github.io/mongo-java-driver
+       */
+
+      MongoClient mongoClient = new MongoClient(
+          new MongoClientURI(
+              "mongodb://localhost:27017/?readPreference=primary&appname=mongodb-vscode+0.7.0&directConnection=true&ssl=false"
+          )
+      );
+      MongoDatabase database = mongoClient.getDatabase("mongodbVSCodePlaygroundDB");
+      MongoCollection<Document> collection = database.getCollection("sales");
+
+      FindIterable<Document> result = collection.aggregate(Arrays.asList(new Document("$match", 
+          new Document("date", 
+          new Document("$gte", 
+          new java.util.Date(1388534400000L))
+                      .append("$lt", 
+          new java.util.Date(1420070400000L)))), 
+          new Document("$group", 
+          new Document("_id", "$item")
+                  .append("totalSaleAmount", 
+          new Document("$sum", 
+          new Document("$multiply", Arrays.asList("$price", "$quantity")))))));
+
+   .. note::
+
+      Export options vary by the selected export language.
+
+...

--- a/source/includes/steps-export-to-language-query.yaml
+++ b/source/includes/steps-export-to-language-query.yaml
@@ -1,0 +1,70 @@
+title: Highlight the code you want to export.
+level: 4
+ref: highlight-code
+content: |
+
+   Highlight the query document from the playground template:
+
+   .. code-block:: json
+
+      { date: { $gte: new Date('2014-04-04'), $lt: new Date('2014-04-05') } }
+
+---
+title: Export your selection.
+level: 4
+ref: export-selection
+content: |
+
+   .. include:: /includes/fact-export-selection.rst
+
+   For example, exporting the query document from Step 1 to Java results
+   in the following code:
+
+   .. code-block:: java
+
+      new Document("date", new Document("$gte", new java.util.Date(1396569600000L))
+              .append("$lt", new java.util.Date(1396656000000L)))
+---
+title: Configure Export Options
+level: 4
+ref: export-options
+content: |
+
+   .. include:: /includes/fact-export-options.rst
+
+   Including both import statements and driver syntax
+   for the preceding Java code results in this output:
+
+   .. code-block:: java
+
+      import org.bson.Document;
+      import com.mongodb.MongoClient;
+      import com.mongodb.MongoClientURI;
+      import com.mongodb.client.FindIterable;
+      import com.mongodb.client.MongoCollection;
+      import com.mongodb.client.MongoDatabase;
+      import org.bson.conversions.Bson;
+      import java.util.concurrent.TimeUnit;
+      import org.bson.Document;
+
+      /*
+      * Requires the MongoDB Java Driver.
+      * https://mongodb.github.io/mongo-java-driver
+      */
+
+      MongoClient mongoClient = new MongoClient(
+          new MongoClientURI(
+              "mongodb://localhost:27017/?readPreference=primary&appname=mongodb-vscode+0.7.0&directConnection=true&ssl=false"
+          )
+      );
+      MongoDatabase database = mongoClient.getDatabase("mongodbVSCodePlaygroundDB");
+      MongoCollection<Document> collection = database.getCollection("sales");
+
+      FindIterable<Document> result = collection.aggregate(new Document("date", new Document("$gte", new java.util.Date(1396569600000L))
+              .append("$lt", new java.util.Date(1396656000000L))));
+
+   .. note::
+
+      Export options vary by the selected export language.
+
+...

--- a/source/includes/steps-open-new-playground.yaml
+++ b/source/includes/steps-open-new-playground.yaml
@@ -21,14 +21,13 @@ content: |
    :guilabel:`MongoDB:`.
 
    When you run the :guilabel:`MongoDB: Create MongoDB Playground`
-   command, |vsce| opens a playground pre-configured with a few
-   commands.
+   command, |vsce| opens a default playground template pre-configured
+   with a few commands.
 
    .. note::
 
-      You can load new Playgrounds without the template by
-      disabling the :guilabel:`Use Default Template For Playground`
-      setting. To learn more about |vsce| settings, see
-      :ref:`vsce-settings`.
+      To load new Playgrounds without the template, disable the
+      :guilabel:`Use Default Template For Playground` setting. To learn
+      more about |vsce| settings, see :ref:`vsce-settings`.
 
 ...

--- a/source/includes/steps-starting-vsce-individual-fields.yaml
+++ b/source/includes/steps-starting-vsce-individual-fields.yaml
@@ -196,7 +196,7 @@ content: |
                     If you are using 
                     :atlas:`Atlas-managed certificates </security-add-mongodb-users/#select-an-authentication-method>`
                     , your username must be prefaced by "CN="
-                    per `RFC 2253 <https://tools.ietf.org/html/rfc2253>__`. 
+                    per `RFC 2253 <https://tools.ietf.org/html/rfc2253>`__. 
                     For example, the username "X509User" must be 
                     provided as "CN=X509User".
 

--- a/source/playgrounds.txt
+++ b/source/playgrounds.txt
@@ -190,4 +190,5 @@ Consideration for Authentication
 
    /crud-ops
    /run-agg-pipelines
+   /export-to-language
    /require-modules


### PR DESCRIPTION
### Description

New VS Code Extension feature that allows exporting playground code to a programming language.

### JIRA

[DOCSP-19772](https://jira.mongodb.org/browse/DOCSP-19772)

### Staging

[Export a Query or Pipeline to Language](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker-xlarge/DOCSP-19772/export-to-language/)