### PR TITLE
Adjusted default shell

### DIFF
--- a/source/settings.txt
+++ b/source/settings.txt
@@ -46,7 +46,7 @@ The following table lists the available settings for
 
        .. include:: /includes/admonitions/warn-configure-path.rst
 
-     - ``mongo``
+     - ``mongosh``
 
    * - :guilabel:`Show`
      - If enabled, shows the MongoDB view in the Visual Studio Code 


### PR DESCRIPTION
At some point, we changed the default shell to be `mongosh` but never adjusted the documentation.