### PR TITLE
DOCSP-29912 Fix build warning, admonition has been deprecated

### DIFF
--- a/source/includes/steps-atlas-terraform-file-from-template.yaml
+++ b/source/includes/steps-atlas-terraform-file-from-template.yaml
@@ -182,8 +182,7 @@ content: |
        - IP address or CIDR block from which your |service| cluster is
          accessible.
 
-  .. admonition:: Use an Input Variables File to Maximize security
-     :class: admonition-example
+  .. example:: Use an Input Variables File to Maximize security
 
      To maximize security, consider taking the following steps: 
 

--- a/source/includes/steps-atlas-terraform-file-from-template.yaml
+++ b/source/includes/steps-atlas-terraform-file-from-template.yaml
@@ -190,17 +190,15 @@ content: |
         <https://learn.hashicorp.com/terraform/getting-started/variables.html>`__
         file.
 
-        .. example::
+        .. code-block:: none
 
-           .. code-block:: none
+          variable "mongodb_atlas_api_pub_key" {
+            default = "my-public-key"
+          }
 
-              variable "mongodb_atlas_api_pub_key" {
-                default = "my-public-key"
-              }
-
-              variable "mongodb_atlas_api_pri_key" {
-                default = "my-private-key"
-              }
+          variable "mongodb_atlas_api_pri_key" {
+            default = "my-private-key"
+          }
 
      #. Exclude the input variables file from your repository. For
         example, add the filename to the ``.gitignore`` file for your
@@ -208,14 +206,12 @@ content: |
      #. Reference variables from the input variables file in the
         ``main.tf`` file by prefacing them with ``vars.``.
 
-        .. example:: 
+        .. code-block:: none
 
-           .. code-block:: none
-
-              provider "mongodbatlas" {
-                public_key  = vars.mongodb_atlas_api_pub_key
-                private_key = vars.mongodb_atlas_api_pri_key
-              }
+          provider "mongodbatlas" {
+            public_key  = vars.mongodb_atlas_api_pub_key
+            private_key = vars.mongodb_atlas_api_pri_key
+          }
 ---
 title: "Add optional configuration options to the ``main.tf`` file."
 level: 4


### PR DESCRIPTION
## DESCRIPTION

Fixing build warning for the deprecated notice on `steps-atlas-terraform-file-from-template.yaml`.

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-vscode/docsworker-xlarge/DOCSP-29912/create-cluster-terraform/#update-the-local-variables

## JIRA

https://jira.mongodb.org/browse/DOCSP-29912

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64639a11df0f8173e92ba482


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)