### PR TITLE
DOCSP-34836 Playgrounds Default DB in Connection String

### DIFF
--- a/source/playgrounds.txt
+++ b/source/playgrounds.txt
@@ -177,14 +177,14 @@ an active connection, |vsce| displays
          autocompletes only for collection names available on the default 
          database. 
          
-   .. step:: Press :guilabel:`Enter`.
+   .. step:: Press :guilabel:`Enter`
 
       After you enter your connection string, a confirmation message replaces 
       the :guilabel:`Click here to add connection` link. The confirmation 
       message includes information on the connected deployment and, if 
       applicable, the default database. 
       
-   .. step:: Run your playground.
+   .. step:: Run your playground
 
 .. note::
 

--- a/source/playgrounds.txt
+++ b/source/playgrounds.txt
@@ -150,19 +150,41 @@ If you have a playground file open in |vscode-short| and do not have
 an active connection, |vsce| displays
 :guilabel:`Click here to add connection` at the top of your playground.
 
-.. figure:: /images/vsce-playground-add-connection-btn.png
-   :figwidth: 700px
-   :alt: Link to add connection from playground
-
-1. Click this link to open the connection string dialog.
-
-#. Enter the
-   :manual:`connection string </reference/connection-string/>` for the
-   deployment you want to run this playground against.
+.. procedure::
+   :style: normal
    
-#. Press :guilabel:`Enter`.
+   .. step:: Select :guilabel:`Click here to add connection` 
 
-#. Run your playground.
+      After you click :guilabel:`Click here to add connection`, |vsce| opens the 
+      connection string dialog.
+
+      .. figure:: /images/vsce-playground-add-connection-btn.png
+         :figwidth: 700px
+         :alt: Link to add connection from playground
+         
+   .. step:: Enter your connection string
+      
+      Enter the :manual:`connection string </reference/connection-string/>` for 
+      the deployment you want to run this playground against.
+
+      .. note:: 
+         
+         If the connection string specifies a database, the playground runs 
+         against the default connected database unless you explicitly call 
+         ``use('<database_name>')``  to use another database.
+
+         If you are connected to a default database, the playground 
+         autocompletes only for collection names available on the default 
+         database. 
+         
+   .. step:: Press :guilabel:`Enter`.
+
+      After you enter your connection string, a confirmation message replaces 
+      the :guilabel:`Click here to add connection` link. The confirmation 
+      message includes information on the connected deployment and, if 
+      applicable, the default database. 
+      
+   .. step:: Run your playground.
 
 .. note::
 


### PR DESCRIPTION
## DESCRIPTION
- Updated steps to use procedure directive
- Included note on behavior when connection string specifies a default database and how to use a a different one if necessary.

## STAGING


## JIRA
https://jira.mongodb.org/browse/DOCSP-34836

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)