### PR TITLE
DOCSP-35013 Remove Public Preview on Settings Page

### DIFF
--- a/source/includes/fact-vsce-preview.rst
+++ b/source/includes/fact-vsce-preview.rst
@@ -1,5 +1,0 @@
-.. note:: Preview
-
-   |vsce| is currently available as a **Preview** in the Visual Studio
-   Marketplace. The product, its features, and the corresponding
-   documentation may change during the Preview stage.

--- a/source/settings.txt
+++ b/source/settings.txt
@@ -12,8 +12,6 @@
    :depth: 1
    :class: singlecol
 
-.. include:: includes/fact-vsce-preview.rst
-
 This document lists the configurable settings for |vsce|.
 
 Configure Settings


### PR DESCRIPTION
## DESCRIPTION

Removing public preview banner from the settings page.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/mongodb-vscode/DOCSP-35013/settings/

## JIRA

https://jira.mongodb.org/browse/DOCSP-35013

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6579bf6a7a5cb5fef5b60143

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)