### PR TITLE
DOCSP-35991 Add Additional Export Languages

### DIFF
--- a/source/export-to-language.txt
+++ b/source/export-to-language.txt
@@ -17,10 +17,13 @@ from a :ref:`playground <vsce-playgrounds>` into a programming language.
 You can export queries and pipelines to the following languages:
 
 - C# 
+- Go
 - Java 
 - Node.js
 - Python
+- PHP
 - Ruby
+- Rust
 
 Prerequisites
 -------------

--- a/source/export-to-language.txt
+++ b/source/export-to-language.txt
@@ -20,8 +20,8 @@ You can export queries and pipelines to the following languages:
 - Go
 - Java 
 - Node.js
-- Python
 - PHP
+- Python
 - Ruby
 - Rust
 


### PR DESCRIPTION
## DESCRIPTION

Adding `Go`, `PHP`, and `Rust` to the additional export languages to the VSCode export page.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/mongodb-vscode/DOCSP-35991/export-to-language/#export-a-query-or-pipeline-to-language

## JIRA

https://jira.mongodb.org/browse/DOCSP-35991

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65b8155e6b2f17c95a905b33

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)