### PR TITLE
DOCSP-36252: typo fix

### DIFF
--- a/source/playgrounds.txt
+++ b/source/playgrounds.txt
@@ -219,7 +219,7 @@ MongoDB Playgrounds are JavaScript files and can work with popular
 and `ESLint <https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint>`_.
 
 If you use a code formatting extension, MongoDB Playgrounds 
-suggest autocompletion and liniting hints for:
+suggest autocompletion and linting hints for:
 
 - System variables such as ``$$ROOT`` and ``$$NOW``
 - ``use`` and ``db`` commands


### PR DESCRIPTION
## DESCRIPTION
Typo discovered during translation audit.

## STAGING
https://preview-mongodbsaraholsonmongodb.gatsbyjs.io/mongodb-vscode/DOCSP-36252/playgrounds/#code-formatting-and-linting-tools

## JIRA
https://jira.mongodb.org/browse/DOCSP-36252

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65bd3e9e6b2f17c95a329f31

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)