### PR TITLE
DOCSP-36256 Fix Replica Set Glossary Warning

### DIFF
--- a/source/includes/steps-starting-vsce-connect-with-advanced-connection-settings.yaml
+++ b/source/includes/steps-starting-vsce-connect-with-advanced-connection-settings.yaml
@@ -4,13 +4,33 @@ source:
   file: steps-open-mongodb-view.yaml
   ref: open-mongodb-view
 ---
-title: Open the |vsce| *Overview* page from the Command Palette or from 
-       the :guilabel:`MongoDB` view in the :guilabel:`Activity Bar`.
+title: Open the |vsce| Overview page
 level: 4
 ref: create-connection
 content: |
 
+  You can use the the MongoDB view or the Command Palette to open the 
+  overview page:
+
   .. tabs:: 
+
+     .. tab:: Open from MongoDB View 
+        :tabid: mdbview 
+
+        a. Expand the :guilabel:`Connections` pane in the left 
+           navigation if it's collapsed.
+
+           .. figure:: /images/vsce-expand-connections.png
+              :figwidth: 600px
+              :alt: Image showing connections pane
+
+        #. Click the :guilabel:`More Actions` menu (:guilabel:`...`), 
+           then click :guilabel:`Add MongoDB Connection` to open the 
+           |vsce| *Overview* page.
+
+           .. figure:: /images/vsce-mongodb-connection-dots.png
+              :figwidth: 600px
+              :alt: Image showing connections pane dots
 
      .. tab:: Open from Command Palette 
         :tabid: mdboverview
@@ -25,34 +45,30 @@ content: |
 
            .. include:: /includes/admonitions/tip-mongodb-command-palette.rst
 
-     .. tab:: Open from MongoDB View 
-        :tabid: mdbview 
-
-        a. Expand the :guilabel:`Connections` pane in the left 
-           navigation if it's collapsed.
-
-        #. Click the :guilabel:`More Actions` menu (:guilabel:`...`), 
-           then click :guilabel:`Add MongoDB Connection` to open the 
-           |vsce| *Overview* page.
-
 ---
-title: In the *Overview* page, click :guilabel:`Open form` under 
-       :guilabel:`Advanced Connection Settings` to create a connection to a deployment.
+title: Open the Advanced Connection Settings Form
 level: 4
 ref: vsce-advanced-connection-settings
+content: |
+
+           On the *Overview* page, click :guilabel:`Open form` under 
+           :guilabel:`Advanced Connection Settings`.
+
+           .. figure:: /images/vsce-mongodb-connection-screen.png
+              :figwidth: 600px
+              :alt: Image showing connections pane screen
+
 ---
-title: Enter your connection information.
+title: Enter your connection information
 ref: vsce-enter-connection-info
 content: |
 
-  .. note::
+  .. important::
 
-     If you want to connect to your deployment using a connection
-     string, click :guilabel:`Connect with a connection string`, then 
-     paste your connection string into the Command Palette. 
+     |vsce| **does not** support the following connection options:
 
-     For more information, see the **Paste Connection String** tab in 
-     :ref:`vsce-connect-task`.
+     - CSFLE In-Use Encryption
+     - Kerberos Authentication
 
   The :guilabel:`General` tab contains the following options:
 
@@ -65,7 +81,7 @@ content: |
 
      * - :guilabel:`Connection Type`
        - Type of connection. Select your connection type from the tabs 
-         below for specific instructions for defining that connection 
+         for specific instructions for defining that connection 
          type:
        
          .. tabs:: 
@@ -174,18 +190,20 @@ content: |
          authentication. |service| clusters use :guilabel:`Username 
          / Password` authentication.
          
-         Select your authentication method from the tabs below for
+         Select your authentication method for
          specific instructions:
 
          .. tabs::
 
            tabs:
+
              - id: username-pw
                name: Username / Password
                content: |
                  Select :guilabel:`Username / Password` if the
-                 deployment uses either MongoDB-CR or
-                 :manual:`SCRAM-SHA-1 </core/security-scram/>` as its
+                 deployment uses MongoDB-CR,
+                 :manual:`SCRAM-SHA-1 </core/security-scram/>`, or  
+                 :manual:`SCRAM-SHA-256 </core/security-scram/>` as its
                  authentication mechanism.
                  
                  Provide the :guilabel:`Username`, :guilabel:`Password`,
@@ -193,39 +211,42 @@ content: |
                  </core/security-users/#user-authentication-database>`
                  to authenticate the user.
 
-                 .. note::
-
-                    Starting in MongoDB version 4.0, MongoDB removes
-                    support for the deprecated MongoDB
-                    Challenge-Response (``MONGODB-CR``) authentication
-                    mechanism.
-
-             - id: scram-sha-256
-               name: SCRAM-SHA-256
+             - id: OIDC
+               name: OIDC
                content: |
-                 Select :guilabel:`SCRAM-SHA-256` if the deployment uses
-                 :manual:`SCRAM-SHA-256 </core/security-scram/>` as its
-                 authentication mechanism (*New in MongoDB 4.0*). If
-                 selected, you must provide the :guilabel:`Username`,
-                 :guilabel:`Password`, and :manual:`Authentication
-                 Database
-                 </core/security-users/#user-authentication-database>`
-                 to authenticate the user.
+               
+                 Select :guilabel:`OIDC` if the deployment uses :manual:`OpenID Connect </core/security-oidc/>` 
+                 as its authentication mechanism.
+      
+                 Provide the following information:
 
-                 For more information on the ``SCRAM``
-                 authentication mechanism, see :manual:`SCRAM
-                 </core/security-scram/>`.
+                 .. list-table::
+                    :header-rows: 1
+                    :widths: 50 50
 
-             - id: ldap
-               name: LDAP
-               content: |
+                    * - Field
+                      - Description
 
-                 Select :guilabel:`LDAP` if the deployment
-                 uses :manual:`LDAP </core/security-ldap-external/>`
-                 as its authentication mechanism. If selected, you
-                 must provide the :guilabel:`Username` and
-                 :guilabel:`Password` to authenticate
-                 the user.
+                    * - Username
+                      - Optional. OpenID Connect username.
+
+                    * - Auth Code Flow Redirect URI
+                      - Optional. Specify a URI where the identity provider redirects you after authentication.
+                        The URI must match the configuration of the Identity Provider.
+                        The default is ``http://localhost:27097/redirect``.
+
+                    * - Consider Target Endpoint Trusted
+                      - Optional. Allows connecting to a target endpoint that is not in the 
+                        list of endpoints that are considered trusted by default. Only use 
+                        this option when connecting to servers that you trust.
+
+                    * - Enable Device Authentication Flow
+                      - Optional. When the :guilabel:`Show Device Auth Flow Checkbox`
+                        setting is enabled, |vscode-short| can provide you with a URL and code 
+                        to finish authentication. 
+
+                 This is a less secure authentication flow that can be used as a 
+                 fallback when browser-based authentication is unavailable.
 
              - id: x509
                name: X.509
@@ -245,6 +266,48 @@ content: |
                     per `RFC 2253 <https://tools.ietf.org/html/rfc2253>`__. 
                     For example, the username "X509User" must be 
                     provided as "CN=X509User".
+
+             - id: ldap
+               name: LDAP
+               content: |
+
+                 Select :guilabel:`LDAP` if the deployment
+                 uses :manual:`LDAP </core/security-ldap-external/>`
+                 as its authentication mechanism. If selected, you
+                 must provide the :guilabel:`Username` and
+                 :guilabel:`Password` to authenticate
+                 the user.
+
+             - id: AWS-IAM
+               name: AWS IAM
+               content: |
+
+                 Select AWS IAM if the deployment uses 
+                 `AWS IAM <https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html>`__ 
+                 as its authentication mechanism.
+
+                 .. list-table::
+                    :header-rows: 1
+                    :widths: 40 20 40
+
+                    * - Field
+                      - Necessity
+                      - Description
+
+                    * - AWS Access Key Id
+                      - Required
+                      - Unique identifier associated with your AWS 
+                        account.
+
+                    * - AWS Secret Access Key
+                      - Optional
+                      - Long-term credential associated with the access 
+                        key ID.
+
+                    * - AWS Session Token
+                      - Optional
+                      - A temporary security credential that is 
+                        returned by the AWS Security Token Service (STS).
 
   If you are connecting to your deployment using TLS/SSL or an SSH
   tunnel, refer to the following tabs for specific instructions:
@@ -428,13 +491,13 @@ content: |
            tunnel. |vsce| cannot establish a connection
            to multiple servers across the same SSH tunnel.
 ---
-title: "Specify read preference in the :guilabel:`Advanced` tab."
+title: "Specify additional options in the :guilabel:`Advanced` tab"
 level: 4
 optional: true
 ref: connect-additional-options
 content: |
   You can select the :guilabel:`Read Preference`, which specifies how 
-  |vsce| directs read operations. Options are:
+  |vsce| directs read operations:
 
   .. list-table::
      :header-rows: 1
@@ -467,8 +530,33 @@ content: |
   If omitted, defaults to :guilabel:`Primary`. To learn more about read 
   preferences, see :manual:`Read Preference </core/read-preference/>`. 
 
+  You can specify additional MongoDB connection behavior with the 
+  following options:
+
+  .. list-table::
+     :header-rows: 1
+     :widths: 20 50
+
+     * - Field
+       - Description
+
+     * - Replica Set Name
+       - (Optional) Name of replica set.
+
+     * - Default Authentication Database
+       - (Optional) Authentication database used when authSource is not specified.
+         For more information, see :manual:`Authentication Options 
+         </reference/connection-string/#authentication-options>`.
+
+     * - URI Options
+       - Additional options to customize your connection. You 
+         specify these options as key-value pairs, and |vscode-short| 
+         automatically adds the key-value pairs to the connection string. 
+         For more information, see :manual:`Connection String Options 
+         </reference/connection-string/#connection-string-options>`.
+
 ---
 ref: vsce-click-connect
 level: 4
-title: "Click :guilabel:`Connect`."
+title: "Click :guilabel:`Connect`"
 ...


### PR DESCRIPTION
## DESCRIPTION

There are `:term:` definitions for replica set on both https://www.mongodb.com/docs/atlas/reference/glossary/ and https://www.mongodb.com/docs/manual/reference/glossary/. When adding intersphinx references to both the manual throws a warning:

```
ERROR(includes/steps-starting-vsce-individual-fields.yaml:379ish): Ambiguous target: "term:replica set". Locations: https://www.mongodb.com/docs/manual/reference/glossary/#std-term-replica-set, https://www.mongodb.com/docs/atlas/reference/glossary/#std-term-replica-set
```

## STAGING


## JIRA


## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)