### PR TITLE
DOCSP-36256 Fix Glossary Warning

### DIFF
--- a/source/includes/steps-starting-vsce-individual-fields.yaml
+++ b/source/includes/steps-starting-vsce-individual-fields.yaml
@@ -424,7 +424,7 @@ content: |
 
         .. note::
 
-           You cannot connect to a :term:`replica set` via an SSH
+           You cannot connect to a :ref:`replica set <replication>` via an SSH
            tunnel. |vsce| cannot establish a connection
            to multiple servers across the same SSH tunnel.
 ---


### PR DESCRIPTION
## DESCRIPTION

There are `:term:` definitions for replica set on both https://www.mongodb.com/docs/atlas/reference/glossary/ and https://www.mongodb.com/docs/manual/reference/glossary/. When adding intersphinx references to both the manual and atlas snooty throws a warning:

```
ERROR(includes/steps-starting-vsce-individual-fields.yaml:379ish): Ambiguous target: "term:replica set". Locations: https://www.mongodb.com/docs/manual/reference/glossary/#std-term-replica-set, https://www.mongodb.com/docs/atlas/reference/glossary/#std-term-replica-set
```


## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/mongodb-vscode/DOCSP-36256/connect/

## JIRA

https://jira.mongodb.org/browse/DOCSP-36256

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65bd5ecd6b2f17c95a41e20f

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)