### PR TITLE
DOCSP-28039 add doc for bucketMaxSpanSeconds & bucketRoundingSeconds

### DIFF
--- a/source/time-series-collections.txt
+++ b/source/time-series-collections.txt
@@ -84,7 +84,9 @@ template.
     {
        timeseries: {
           timeField: "timestamp",
-          granularity: "hours"
+          granularity: "hours",
+          bucketMaxSpanSeconds: 60,
+          bucketRoundingSeconds: 60
        }
     }
   )
@@ -100,6 +102,12 @@ In the example:
 
   - ``granularity: "hours"`` defines the time scale by which the documents
     are stored. 
+
+  - ``bucketMaxSpanSeconds`` defines a maximum time span of 60 seconds
+    for each bucket.
+
+  - ``bucketRoundingSeconds`` specifies the time interval that
+    determines the starting timestamp for a new bucket. 
 
 When you press the :guilabel:`Play Button`, MongoDB for VS Code splits your 
 Playground and outputs the following result in the Playground Results.json 


### PR DESCRIPTION
## DESCRIPTION
Adds documentation for bucketMaxSpanSeconds & bucketRoundingSeconds to the timeseries template

## STAGING
https://preview-mongodbkanchanamongodb.gatsbyjs.io/mongodb-vscode/DOCSP-28039/time-series-collections/#example

## JIRA
https://jira.mongodb.org/browse/DOCSP-28039

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65d4fd4c711116598284f846 (clean)

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)