### PR TITLE
DOCSP-37231: translation typo fix

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -135,7 +135,7 @@ For details on how to configure Atlas Stream Processing, see
       To obtain an SPI connection string login to your 
       `Atlas <https://cloud.mongodb.com>`__ account.
       Click :guilabel:`Stream Processing` from the left-hand navigation 
-      and then select a Stream Processor Instance. Click 
+      and then select a Stream Processing Instance. Click 
       :guilabel:`Connect` and choose :guilabel:`MongoDB for VSCode` from
       the :guilabel:`Choose a Connection Method` page of the connect 
       dialog.


### PR DESCRIPTION
## DESCRIPTION
fix typo reported by linguists working on translation

## STAGING
https://preview-mongodbjwilliamsmongo.gatsbyjs.io/mongodb-vscode/DOCSP-37231/connect/#connect-to-atlas-stream-processing

## JIRA
https://jira.mongodb.org/browse/DOCSP-37231

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65e0c08f11db7b04273cf866

## Self-Review Checklist

- [x ] Is this free of any warnings or errors in the RST?
- [ x] Is this free of spelling errors?
- [x ] Is this free of grammatical errors?
- [ x] Is this free of staging / rendering issues?
- [x ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)