### PR TITLE
DOCSP-39185 Require local files in playgrounds

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -5,7 +5,12 @@ intersphinx = ["https://www.mongodb.com/docs/manual/objects.inv",
                "https://www.mongodb.com/docs/atlas/objects.inv"
               ]
 
-toc_landing_pages = ["/playgrounds", "/crud-ops", "/playground-databases"]
+toc_landing_pages = [
+    "/playgrounds",
+    "/crud-ops",
+    "/playground-databases",
+    "/require-playgrounds"
+]
 
 [constants]
 

--- a/source/playgrounds.txt
+++ b/source/playgrounds.txt
@@ -266,4 +266,4 @@ Consideration for Authentication
    /run-agg-pipelines
    /enable-autocomplete-for-string-literals
    /export-to-language
-   /require-modules
+   /require-playgrounds

--- a/source/require-playgrounds.txt
+++ b/source/require-playgrounds.txt
@@ -11,9 +11,9 @@ Use require() in Playgrounds
    :class: singlecol
 
 You can use the `require()
-<https://nodejs.org/api/modules.html#modules_require_id>`__ function to
-re-use code in your playgrounds. The code you include with ``require()``
-can be either:
+<https://nodejs.org/api/modules.html#modules_require_id>`__ function in
+your playgrounds to reuse code in your playgrounds. The code you
+include with ``require()`` can be either:
 
 - A native Node module (such as `fs
   <https://nodejs.org/api/fs.html#fs_file_system>`__)
@@ -26,7 +26,14 @@ can be either:
 Use Cases
 ---------
 
-(?)
+Using ``require()`` to import code helps keep your playgrounds
+organized. If you are often performing the same tasks in your
+playgrounds, you can use ``require()`` to reuse code and avoid writing
+out full functions in each of your playgrounds.
+
+For example, consider the following scenarios where you can reuse code:
+
+- 
 
 Get Started
 -----------

--- a/source/require-playgrounds.txt
+++ b/source/require-playgrounds.txt
@@ -1,0 +1,39 @@
+.. _vsce-require-landing:
+
+============================
+Use require() in Playgrounds
+============================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+You can use the `require()
+<https://nodejs.org/api/modules.html#modules_require_id>`__ function to
+re-use code in your playgrounds. The code you include with ``require()``
+can be either:
+
+- A native Node module (such as `fs
+  <https://nodejs.org/api/fs.html#fs_file_system>`__)
+
+- An external Node module downloaded from `npm
+  <https://www.npmjs.com/>`__
+
+- A local JavaScript file
+
+Use Cases
+---------
+
+(?)
+
+Get Started
+-----------
+
+To learn how to use ``require()`` in your playgrounds, see the following
+tutorials:
+
+- :ref:`vsce-require`
+
+- :ref:`vsce-require-local`

--- a/source/require-playgrounds.txt
+++ b/source/require-playgrounds.txt
@@ -31,9 +31,19 @@ organized. If you are often performing the same tasks in your
 playgrounds, you can use ``require()`` to reuse code and avoid writing
 out full functions in each of your playgrounds.
 
-For example, consider the following scenarios where you can reuse code:
+For example, consider the following scenarios where reusing code can
+simplify code and improve productivity:
 
-- 
+- You need to ensure that documents are inserted with a consistent
+  structure. You can import a JavaScript file to validate the data
+  format before the playground script performs the insert.
+
+- You store monetary data and want to convert values between different
+  currencies. You can import a JavaScript function to perform conversion
+  calculations.
+
+- You need to import data from files on your local computer. You can use
+  the native Node module ``fs`` to read data from local files.
 
 Get Started
 -----------

--- a/source/require-playgrounds.txt
+++ b/source/require-playgrounds.txt
@@ -37,3 +37,9 @@ tutorials:
 - :ref:`vsce-require`
 
 - :ref:`vsce-require-local`
+
+.. toctree::
+   :titlesonly:
+
+   /require-playgrounds/require-modules
+   /require-playgrounds/require-local

--- a/source/require-playgrounds/require-local.txt
+++ b/source/require-playgrounds/require-local.txt
@@ -130,4 +130,4 @@ Learn More
 
 - :ref:`vsce-require`
 
-- :require:`vsce-playground-databases`
+- :ref:`vsce-playground-databases`

--- a/source/require-playgrounds/require-local.txt
+++ b/source/require-playgrounds/require-local.txt
@@ -9,3 +9,125 @@ Use require() to Load Local Files
    :backlinks: none
    :depth: 1
    :class: singlecol
+
+You can use the `require()
+<https://nodejs.org/api/modules.html#modules_require_id>`__ function in
+your MongoDB Playgrounds to include code from local files. You can
+import script functions to store your code in a single location and
+reuse that code in different playgrounds.
+
+About this Task
+---------------
+
+This tutorial describes using ``require()`` to load local scripts. You
+can also use ``require()`` to load Node modules, like those downloaded
+from `npm <https://www.npmjs.com/>`__. For more information on using
+``require()`` with Node modules, see :ref:`vsce-require`.
+
+Steps
+-----
+
+.. procedure::
+   :style: normal
+   
+   .. step:: Create a script file
+
+      The following example script file validates documents to ensure
+      that the required fields are present. Save the script to your
+      local filesystem as ``validate.js``:
+
+      .. code-block:: javascript
+
+         // validate.js
+
+         const required_fields = [ 'name', 'email' ]
+
+         const validate_data = (document) => {
+
+            let is_valid = true;
+
+            required_fields.forEach((field) => {
+               if (document[field] == null) {
+                     is_valid = false;
+               }
+            } );
+            return is_valid;
+         };
+
+         module.exports = validate_data;
+
+   .. step:: Create a playground that uses the validation script
+
+      The following playground script uses ``require()`` to call the
+      ``validate_data`` function specified in ``validate.js``. The
+      ``validate_data`` function is called on two sample documents. If
+      the document contains the required fields ``name`` and ``email``,
+      it is inserted into the ``people`` collection.
+
+      .. important::
+
+         Update the first line of the playground with the path to the
+         ``validate.js`` file:
+
+      .. code-block:: javascript
+
+         // playground-1.mongodb.js
+
+         const validate = require('/path/to/validate.js');
+
+         use('mongodbVSCodePlaygroundDB');
+
+         const doc1 = { 'name': 'Taylor', 'email': 't123@gmail.com' }
+
+         const doc2 = { 'name': 'Taylor' }
+
+         const docs = [doc1, doc2]
+
+         let inserted_count = 0;
+
+         docs.forEach((doc) => {
+            if(validate(doc)) {
+               db.getCollection('people').insertOne(doc);
+               inserted_count++;
+            }
+         } );
+
+         console.log("Inserted " + inserted_count + " document(s)")
+
+Results
+-------
+
+Only one of the sample documents contained both required fields.
+Therefore, ``doc1`` is inserted into the ``people`` collection, and
+``doc2`` is not inserted.
+
+To confirm that the document was inserted, query the ``people``
+collection:
+
+.. code-block:: javascript
+
+   use mongodbVSCodePlaygroundDB
+
+   db.people.find()
+
+Output:
+
+.. code-block:: javascript
+   :copyable: false
+
+   [
+      {
+         _id: ObjectId("664cf216ae6252c96b7de8b7"),
+         name: 'Taylor',
+         email: 't123@gmail.com'
+      }
+   ]
+
+Learn More
+----------
+
+- :ref:`schema-validation-overview`
+
+- :ref:`vsce-require`
+
+- :require:`vsce-playground-databases`

--- a/source/require-playgrounds/require-local.txt
+++ b/source/require-playgrounds/require-local.txt
@@ -1,0 +1,11 @@
+.. _vsce-require-local:
+
+=================================
+Use require() to Load Local Files
+=================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol

--- a/source/require-playgrounds/require-modules.txt
+++ b/source/require-playgrounds/require-modules.txt
@@ -1,8 +1,8 @@
 .. _vsce-require:
 
-====================================
-Use ``require()`` to Include Modules
-====================================
+============================================
+Use ``require()`` to Include Node.js Modules
+============================================
 
 .. default-domain:: mongodb
 
@@ -19,10 +19,11 @@ Use ``require()`` to Include Modules
    function is out of scope for this tutorial. To learn more, refer to
    the `Node.js Documentation <https://nodejs.org/api/modules.html>`__.
 
-You can use the
-`require() <https://nodejs.org/api/modules.html#modules_require_id>`__
-function in your MongoDB Playgrounds to
-include modules which exist in separate files.
+You can use the `require()
+<https://nodejs.org/api/modules.html#modules_require_id>`__ function in
+your MongoDB Playgrounds to include functionality from Node.js modules.
+You can use modules to import reusable code to simplify your
+playgrounds.
 
 Require Native Modules
 ----------------------

--- a/source/require-playgrounds/require-modules.txt
+++ b/source/require-playgrounds/require-modules.txt
@@ -1,8 +1,8 @@
 .. _vsce-require:
 
-============================================
-Use ``require()`` to Include Node.js Modules
-============================================
+========================================
+Use require() to Include Node.js Modules
+========================================
 
 .. default-domain:: mongodb
 

--- a/source/require-playgrounds/require-modules.txt
+++ b/source/require-playgrounds/require-modules.txt
@@ -1,8 +1,8 @@
 .. _vsce-require:
 
-=============================================
-Use ``require()`` to Include External Modules
-=============================================
+====================================
+Use ``require()`` to Include Modules
+====================================
 
 .. default-domain:: mongodb
 


### PR DESCRIPTION
## DESCRIPTION

Add tutorial for requiring local js scripts in playgrounds

## STAGING

- [Use require in Playgrounds](https://preview-mongodbjeffallenmongo.gatsbyjs.io/mongodb-vscode/DOCSP-39185/require-playgrounds/)
- [Use require to Include Node.js modules)[https://preview-mongodbjeffallenmongo.gatsbyjs.io/mongodb-vscode/DOCSP-39185/require-playgrounds/require-modules/] (small modifications to the intro of this page)
- [Use require to Load Local Files](https://preview-mongodbjeffallenmongo.gatsbyjs.io/mongodb-vscode/DOCSP-39185/require-playgrounds/require-local/)

## JIRA

https://jira.mongodb.org/browse/DOCSP-39185

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=664d0660cf5bec1c297c87d0

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)