### PR TITLE
DOCSP-44570-incorrect-heading

### DIFF
--- a/source/copilot.txt
+++ b/source/copilot.txt
@@ -32,7 +32,7 @@ Commands
 The ``/query`` command assists in generating queries from a natural
 language against a connected MongoDB cluster.
 
-:ref:`/query <vsce-copilot-schema>`
+:ref:`/schema <vsce-copilot-schema>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``schema`` command provides schema information about collections in

--- a/source/copilot.txt
+++ b/source/copilot.txt
@@ -33,7 +33,7 @@ The ``/query`` command assists in generating queries from a natural
 language against a connected MongoDB cluster.
 
 :ref:`/schema <vsce-copilot-schema>`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``schema`` command provides schema information about collections in
 your connected deployment.


### PR DESCRIPTION
## DESCRIPTION
One of the listed commands says `/query` but it is supposed to be `/schema`. 


## STAGING
https://deploy-preview-100--docs-mongodb-vscode.netlify.app/copilot/

## JIRA
https://jira.mongodb.org/browse/DOCSP-44570

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)