### PR TITLE
DOCSP-44641-retrieval-typo

### DIFF
--- a/source/copilot-docs.txt
+++ b/source/copilot-docs.txt
@@ -14,7 +14,7 @@
 
 The ``/docs`` command provides MongoDB-specific information,
 supplemented by links to MongoDB Documentation. The |copilot| uses
-Retrival-Augmented Generation (RAG) to generate responses based on the
+Retrieval-Augmented Generation (RAG) to generate responses based on the
 latest version of MongoDB Documentation.
 
 Examples


### PR DESCRIPTION
## DESCRIPTION
In the first paragraph of the ['/docs' command page](https://www.mongodb.com/docs/mongodb-vscode/copilot-docs/) under the 'MongoDB Extension for GitHub Copilot' tree, we say "...Copilot uses Retrival-Augmented Generation (RAG)..." – 'retrival' is a typo – this PR changes it to be 'retrieval'.

## STAGING
https://deploy-preview-101--docs-mongodb-vscode.netlify.app/copilot-docs/#-docs-command

## JIRA
https://jira.mongodb.org/browse/DOCSP-44641

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)