### PR TITLE
DOCSP-45571-export-to-language-with-copilot

### DIFF
--- a/source/copilot-export-test.txt
+++ b/source/copilot-export-test.txt
@@ -50,6 +50,9 @@ Use the following steps to test your application code in a playground:
 Once you export your code to a playground, you can click
 :icon-fa5:`play` on the top right of your window to run your query. 
 
+You can also convert your code to a driver language with the
+:ref:`Export to Language <vsce-export-to-language>` feature. 
+
 .. seealso::
 
    - :ref:`vsce-playgrounds`

--- a/source/export-to-language.txt
+++ b/source/export-to-language.txt
@@ -33,7 +33,7 @@ following languages:
 Prerequisites
 -------------
 
-You must enable |copilot| to use the :guilabel:`Export to Language` feature. 
+You must enable the |copilot| to use the :guilabel:`Export to Language` feature. 
 
 You must open a playground that contains a query document or pipeline
 you want to export. 

--- a/source/export-to-language.txt
+++ b/source/export-to-language.txt
@@ -28,11 +28,12 @@ following languages:
 
 .. note::
 
-   The :guilabel:`Export to Language` feature is only available
-   if you enable |copilot|. 
+   
 
 Prerequisites
 -------------
+
+You must enable |copilot| to use the :guilabel:`Export to Language` feature. 
 
 You must open a playground that contains a query document or pipeline
 you want to export. 

--- a/source/export-to-language.txt
+++ b/source/export-to-language.txt
@@ -14,7 +14,7 @@ Export a Query or Pipeline to Language
 
 You can export and translate query documents and aggregation pipelines
 from a :ref:`playground <vsce-playgrounds>` into a programming language
-using the |copilot|. You can export queries and pipelines to the
+using the :ref:`vsce-copilot`. You can export queries and pipelines to the
 following languages:
 
 - C# 

--- a/source/export-to-language.txt
+++ b/source/export-to-language.txt
@@ -13,8 +13,9 @@ Export a Query or Pipeline to Language
    :class: singlecol
 
 You can export and translate query documents and aggregation pipelines
-from a :ref:`playground <vsce-playgrounds>` into a programming language.
-You can export queries and pipelines to the following languages:
+from a :ref:`playground <vsce-playgrounds>` into a programming language
+using the |copilot|. You can export queries and pipelines to the
+following languages:
 
 - C# 
 - Go
@@ -24,6 +25,11 @@ You can export queries and pipelines to the following languages:
 - Python
 - Ruby
 - Rust
+
+.. note::
+
+   The :guilabel:`Export to Language` feature is only available
+   if you enable |copilot|. 
 
 Prerequisites
 -------------
@@ -40,7 +46,6 @@ The tutorials on this page use the default playground template.
 To open a new playground containing the default template:
 
 .. include:: /includes/steps/open-new-playground.rst
-
 
 Export a Query Document
 -----------------------


### PR DESCRIPTION
## DESCRIPTION

The Export to Language feature is now only available if you enable the copilot extension

## STAGING

https://deploy-preview-104--docs-mongodb-vscode.netlify.app/export-to-language/
https://deploy-preview-104--docs-mongodb-vscode.netlify.app/copilot-export-test/

## JIRA

https://jira.mongodb.org/browse/DOCSP-45571

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)